### PR TITLE
do not include the version in the archived path

### DIFF
--- a/src/GenerateArchivedRecipesCommand.php
+++ b/src/GenerateArchivedRecipesCommand.php
@@ -50,6 +50,9 @@ class GenerateArchivedRecipesCommand extends Command
         $process->mustRun();
 
         $tmpDir = sys_get_temp_dir().'/_flex_archive/';
+        if (file_exists($tmpDir)) {
+            $filesystem->remove($tmpDir);
+        }
         $filesystem->mkdir($tmpDir);
 
         $process = (new Process(['git', 'rev-list', '--count', $branch, '--no-merges'], $recipesDirectory))->mustRun();

--- a/src/GenerateFlexEndpointCommand.php
+++ b/src/GenerateFlexEndpointCommand.php
@@ -153,7 +153,7 @@ class GenerateFlexEndpointCommand extends Command
         file_put_contents(sprintf('%s/%s.%s.json', $outputDir, str_replace('/', '.', $package), $version), $contents);
 
         // save another version for the archives
-        $archivedPath = sprintf('%s/archived/%s.%s/%s.json', $outputDir, str_replace('/', '.', $package), $version, $tree);
+        $archivedPath = sprintf('%s/archived/%s/%s.json', $outputDir, str_replace('/', '.', $package), $tree);
         if (!file_exists(\dirname($archivedPath))) {
             mkdir(\dirname($archivedPath), 0777, true);
         }


### PR DESCRIPTION
Left as an accident. https://github.com/symfony/flex/pull/845 does not look for this - it looks for `archived/{PACKAGE NAME]/{TREE REF}.json`.