### PR TITLE
Adding generate:recipes-readme command

### DIFF
--- a/run
+++ b/run
@@ -6,6 +6,7 @@ require __DIR__.'/vendor/autoload_runtime.php';
 use App\DiffRecipeVersionsCommand;
 use App\GenerateArchivedRecipesCommand;
 use App\GenerateFlexEndpointCommand;
+use App\GenerateRecipesReadmeCommand;
 use App\LintManifestsCommand;
 use App\LintPackagesCommand;
 use App\LintPullRequestCommand;
@@ -19,6 +20,7 @@ return function() {
     $app->add(new DiffRecipeVersionsCommand());
     $app->add(new GenerateFlexEndpointCommand());
     $app->add(new GenerateArchivedRecipesCommand());
+    $app->add(new GenerateRecipesReadmeCommand());
     $app->add(new LintManifestsCommand());
     $app->add(new LintPackagesCommand());
     $app->add(new LintPullRequestCommand());

--- a/src/GenerateRecipesReadmeCommand.php
+++ b/src/GenerateRecipesReadmeCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'generate:recipes-readme', description: 'Generates a "README" containing a list of all recipes.')]
+class GenerateRecipesReadmeCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('indexPath', InputArgument::REQUIRED, 'Path to the local index.json')
+            ->addOption('contrib', null, InputOption::VALUE_NONE, 'Is this the contrib repository?')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $indexPath = $input->getArgument('indexPath');
+        $isContrib = $input->getOption('contrib');
+
+        if (!file_exists($indexPath)) {
+            throw new \InvalidArgumentException(sprintf('Cannot find index JSON file "%s"', $indexPath));
+        }
+
+        $data = json_decode(file_get_contents($indexPath), true);
+
+        $aliases = $this->organizeAliases($data['aliases']);
+        $hasAliases = count($aliases) > 0;
+
+        $contentLines = [];
+        $contentLines[] = '# List of Recipes';
+        $contentLines[] = '';
+        if ($isContrib) {
+            $contentLines[] = 'Additional recipes can be found on the [Main Recipes Repository](https://github.com/symfony/recipes/blob/master/RECIPES.md)';
+        } else {
+            $contentLines[] = 'Additional recipes can be found on the [Contrib Recipes Repository](https://github.com/symfony/recipes-contrib/blob/master/RECIPES.md)';
+        }
+        $contentLines[] = '';
+
+        // Package | Latest recipe | Aliases
+        // [symfony/framework-bundle](https://packagist) | [5.4](github.com/.../) | framework-bundle
+        $contentLines[] = '| Package | Latest Recipe |' . ($hasAliases ? ' Aliases |' : '');
+        $contentLines[] = '| --- | --- |' . ($hasAliases ? ' --- |' : '');
+        foreach ($data['recipes'] as $package => $versions) {
+            $latestVersion = array_pop($versions);
+            $line = sprintf('| [%s](https://packagist.org/packages/%s) | [%s](%s/%s) |', $package, $package, $latestVersion, $package, $latestVersion);
+            if ($hasAliases) {
+                $styledAliases = array_map(function($alias) {
+                    return sprintf('`%s`', $alias);
+                }, $aliases[$package] ?? []);
+                $line .= sprintf(' %s |', implode(', ', $styledAliases));
+            }
+
+            $contentLines[] = $line;
+        }
+
+        echo implode("\n", $contentLines);
+
+        return 0;
+    }
+
+    private function organizeAliases(array $aliases): array
+    {
+        $byPackageAliases = [];
+        foreach ($aliases as $alias => $package) {
+            if (!isset($byPackageAliases[$package])) {
+                $byPackageAliases[$package] = [];
+            }
+
+            $byPackageAliases[$package][] = $alias;
+        }
+
+        return $byPackageAliases;
+    }
+}

--- a/src/GenerateRecipesReadmeCommand.php
+++ b/src/GenerateRecipesReadmeCommand.php
@@ -22,18 +22,18 @@ class GenerateRecipesReadmeCommand extends Command
     protected function configure(): void
     {
         $this
-            ->addArgument('indexPath', InputArgument::REQUIRED, 'Path to the local index.json')
+            ->addArgument('index_path', InputArgument::REQUIRED, 'Path to the local index.json')
             ->addOption('contrib', null, InputOption::VALUE_NONE, 'Is this the contrib repository?')
         ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $indexPath = $input->getArgument('indexPath');
+        $indexPath = $input->getArgument('index_path');
         $isContrib = $input->getOption('contrib');
 
         if (!file_exists($indexPath)) {
-            throw new \InvalidArgumentException(sprintf('Cannot find index JSON file "%s"', $indexPath));
+            throw new \InvalidArgumentException(sprintf('Cannot find index JSON file "%s".', $indexPath));
         }
 
         $data = json_decode(file_get_contents($indexPath), true);
@@ -53,13 +53,13 @@ class GenerateRecipesReadmeCommand extends Command
 
         // Package | Latest recipe | Aliases
         // [symfony/framework-bundle](https://packagist) | [5.4](github.com/.../) | framework-bundle
-        $contentLines[] = '| Package | Latest Recipe |' . ($hasAliases ? ' Aliases |' : '');
-        $contentLines[] = '| --- | --- |' . ($hasAliases ? ' --- |' : '');
+        $contentLines[] = '| Package | Latest Recipe |'.($hasAliases ? ' Aliases |' : '');
+        $contentLines[] = '| --- | --- |'.($hasAliases ? ' --- |' : '');
         foreach ($data['recipes'] as $package => $versions) {
             $latestVersion = array_pop($versions);
             $line = sprintf('| [%s](https://packagist.org/packages/%s) | [%s](%s/%s) |', $package, $package, $latestVersion, $package, $latestVersion);
             if ($hasAliases) {
-                $styledAliases = array_map(function($alias) {
+                $styledAliases = array_map(function ($alias) {
                     return sprintf('`%s`', $alias);
                 }, $aliases[$package] ?? []);
                 $line .= sprintf(' %s |', implode(', ', $styledAliases));


### PR DESCRIPTION
Now that flex.symfony.com is gone, it would still be useful to have, at the very least, a list of the Flex aliases that are available.

This command generates a Markdown-formatted list of recipes. A GH action would be added to the recipes and recipes-contrib repos to run this automatically (see https://github.com/symfony/recipes/pull/1078).

Examples: [symfony/recipes RECIPES.md](https://github.com/weaverryan/recipes/blob/testing-readme/RECIPES.md) [symfony/recipes-contrib RECIPES.md](https://github.com/weaverryan/recipes-contrib/tree/testing-readme)

I'm open to any tweaks :) 

Cheers!