### PR TITLE
fix: when manifest doesnt have bundles

### DIFF
--- a/src/LintManifestsCommand.php
+++ b/src/LintManifestsCommand.php
@@ -59,7 +59,7 @@ class LintManifestsCommand extends Command
                     break;
                 }
             }
-            if ($empty && !is_file("$package/$version/post-install.txt") && 'all' === current($data['bundles'])) {
+            if ($empty && !is_file("$package/$version/post-install.txt") && 'all' === current($data['bundles'] ?? [])) {
                 $output->writeln(sprintf('::error file=%s::Recipe is not needed as it only registers a bundle for all environments', $manifest));
                 continue;
             }


### PR DESCRIPTION
Hey,

not all my manifests have bundles. So that line explodes with

                                
  [ErrorException]               
  Undefined array key "bundles"  
                                 