### PR TITLE
feat: Add option to generate Gitlab compatible endpoints

### DIFF
--- a/src/GenerateFlexEndpointCommand.php
+++ b/src/GenerateFlexEndpointCommand.php
@@ -109,12 +109,12 @@ class GenerateFlexEndpointCommand extends Command
             case self::PROVIDER_GITHUB:
                 $baseHost = 'github.com';
                 $recipeTemplate = sprintf('https://raw.githubusercontent.com/%s/%s/{package_dotted}.{version}.json', $repository, $flexBranch);
-                $archivedRecipesTemplate = sprintf('https://raw.githubusercontent.com/%s/%s/archived/{package_dotted}.{version}.json', $repository, $flexBranch);
+                $archivedRecipesTemplate = sprintf('https://raw.githubusercontent.com/%s/%s/archived/{package_dotted}/{ref}.json', $repository, $flexBranch);
                 break;
             case self::PROVIDER_GITLAB:
                 $baseHost = 'gitlab.com';
                 $recipeTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/{package_dotted}.{version}.json/raw?ref=%s', urlencode($repository), $flexBranch);
-                $archivedRecipesTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/archived/{package_dotted}.{version}.json/raw?ref=%s', urlencode($repository), $flexBranch);
+                $archivedRecipesTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/archived%%2F{package_dotted}%%2F{ref}.json/raw?ref=%s', urlencode($repository), $flexBranch);
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Unsupported provider "%s".', $provider));

--- a/src/GenerateFlexEndpointCommand.php
+++ b/src/GenerateFlexEndpointCommand.php
@@ -113,8 +113,8 @@ class GenerateFlexEndpointCommand extends Command
                 break;
             case self::PROVIDER_GITLAB:
                 $baseHost = 'gitlab.com';
-                $recipeTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/{package_dotted}.{version}.json/raw?ref=%s', $repository, $flexBranch);
-                $archivedRecipesTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/archived/{package_dotted}.{version}.json/raw?ref=%s', $repository, $flexBranch);
+                $recipeTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/{package_dotted}.{version}.json/raw?ref=%s', urlencode($repository), $flexBranch);
+                $archivedRecipesTemplate = sprintf('https://gitlab.com/api/v4/projects/%s/repository/files/archived/{package_dotted}.{version}.json/raw?ref=%s', urlencode($repository), $flexBranch);
                 break;
             default:
                 throw new \InvalidArgumentException(sprintf('Unsupported provider "%s".', $provider));


### PR DESCRIPTION
Hi!

The documentation for private recipes repositories include examples for using it with Gitlab.com (https://symfony.com/doc/current/setup/flex_private_recipes.html). But this project do not have the possibility to generate endpoints compatible with it.

I added the option `--provider=`, with default value at "github", in the `generate:flex-endpoint` command to specify a provider (only Github or Gitlab for now). This will change how the `_links` key is generated in the index.json.

Closes #13 