### PR TITLE
Add lint for intended duplicate content, that would be skipped

### DIFF
--- a/src/LintManifestsCommand.php
+++ b/src/LintManifestsCommand.php
@@ -140,6 +140,8 @@ class LintManifestsCommand extends Command
         }
 
         $isValid = true;
+        $targetPerContent = [];
+
         foreach ($data as $index => $addLine) {
             foreach (['file', 'content', 'position'] as $key) {
                 if (!isset($addLine[$key])) {
@@ -174,6 +176,18 @@ class LintManifestsCommand extends Command
 
                         $isValid = false;
                     }
+                }
+
+                $targetPerContent[$addLine['file']][$addLine['content']][] = $addLine['target'];
+            }
+        }
+
+        foreach ($targetPerContent as $file => $filedTargets) {
+            foreach ($filedTargets as $targets) {
+                if (count($targets) > 1) {
+                    $output->writeln(sprintf('::error file=%s::"add-lines" has the same content for the same file "%s" multiple times for different targets "%s". Only the first one would be applied', $manifest, $file, implode('", "', $targets)));
+
+                    $isValid = false;
                 }
             }
         }


### PR DESCRIPTION
I wanted to add some content to a yaml at different places.

To not have the same content duplicated I used yaml pointers. When adding the yaml pointer references at multiple places this line hits: https://github.com/symfony/flex/blob/8ce1acd9842abe0e9b4c4a0bd3f259859516c018/src/Configurator/AddLinesConfigurator.php#L171-L173
It will prevent the additional references to be added as the content is already in the file. It will not print a hint as it is the intended check for a change, that might not have to be applied.

In my case it is intentional and it should be mentioned as early as possible. Therefore I add the check to the manifest lint instead of symfony/flex itself as this will be checked eventually when the recipe has been published already.

Template yaml:

`ci.yml`
```yaml
steps:
# steps

trigger:
  branch:
    main:
      # trigger_main
    stage:
      # trigger_stage
```

Expected result:

```diff
 steps:
 # steps
+  - step: &pointer
 
 trigger:
   branch:
     main:
       # trigger_main
+      - step: *pointer
     stage:
       # trigger_stage
+      - step: *pointer
```

Current result:

```diff
 steps:
 # steps
+  - step: &pointer
 
 trigger:
   branch:
     main:
       # trigger_main
+      - step: *pointer
     stage:
       # trigger_stage
```

I can solve this by having a comment behind the pointer reference usage and to make it unique. But it is such a hassle to debug this until you find this skip so I'd rather be notified about this early :) 

```diff
 steps:
 # steps
+  - step: &pointer
 
 trigger:
   branch:
     main:
       # trigger_main
+      - step: *pointer # at trigger_main
     stage:
       # trigger_stage
+      - step: *pointer # at trigger_stage
```
