### PR TITLE
feat: Allow multiple lines addition with array

### DIFF
--- a/src/GenerateFlexEndpointCommand.php
+++ b/src/GenerateFlexEndpointCommand.php
@@ -123,6 +123,14 @@ class GenerateFlexEndpointCommand extends Command
     {
         unset($manifest['aliases']);
 
+        if (isset($manifest['add-lines']) && is_array($manifest['add-lines'])) {
+            foreach ($manifest['add-lines'] as $i => $config) {
+                if (isset($config['content']) && is_array($config['content'])) {
+                    $manifest['add-lines'][$i]['content'] = implode("\n", $config['content']);
+                }
+            }
+        }
+
         $files = [];
         $it = new \RecursiveDirectoryIterator($package.'/'.$version);
         $it->setFlags($it::SKIP_DOTS | $it::FOLLOW_SYMLINKS | $it::UNIX_PATHS);

--- a/src/LintManifestsCommand.php
+++ b/src/LintManifestsCommand.php
@@ -149,7 +149,24 @@ class LintManifestsCommand extends Command
                     continue;
                 }
 
-                if (!is_string($addLine[$key])) {
+                if ('content' === $key) {
+                    if (!is_string($addLine[$key]) && !is_array($addLine[$key])) {
+                        $output->writeln(sprintf('::error file=%s::"add-lines" (index %d) has a "%s" key but it must be a string or an array of strings', $manifest, $index, $key));
+                        $isValid = false;
+                        
+                        continue;
+                    }
+
+                    if (is_array($addLine[$key])) {
+                        foreach ($addLine[$key] as $lineIndex => $line) {
+                            if (!is_string($line)) {
+                                $output->writeln(sprintf('::error file=%s::"add-lines" (index %d) has a "%s" array but element at index %d is not a string', $manifest, $index, $key, $lineIndex));
+                                
+                                $isValid = false;
+                            }
+                        }
+                    }
+                } elseif (!is_string($addLine[$key])) {
                     $output->writeln(sprintf('::error file=%s::"add-lines" (index %d) has a "%s" key but it must be a string value', $manifest, $index, $key));
 
                     $isValid = false;


### PR DESCRIPTION
This PR improves the developer experience for writing recipes by allowing an array of strings for the content key in the add-lines configurator. First try was on https://github.com/symfony/flex/pull/1034

To ensure 100% backward compatibility with all existing versions of symfony/flex, the implementation is twofold:

`LintManifestsCommand`: The linter is updated to validate and accept an array of strings for the content key. This allows the new, more readable format to be used in the source recipe repositories.

`GenerateFlexEndpointCommand`: During the generation of the public Flex endpoint, the command now automatically detects if content is an array and converts it back into a single, \n-separated string.

Recipe: https://github.com/MforMono/recipes/blob/main/friends-of-behat/mink-extension/2.4/manifest.json
Generated json: https://github.com/MforMono/recipes/blob/flex/main/friends-of-behat.mink-debug-extension.2.0.json