### PR TITLE
Scope the ~dev fallback to the version missing from stable

### DIFF
--- a/src/LintPackagesCommand.php
+++ b/src/LintPackagesCommand.php
@@ -25,13 +25,13 @@ class LintPackagesCommand extends Command
         $packages = [];
 
         foreach (glob('*/*') as $package) {
-            $packages[] = [false, $package, $client->request('GET', "https://repo.packagist.org/p2/{$package}.json")];
+            $packages[] = [false, $package, null, $client->request('GET', "https://repo.packagist.org/p2/{$package}.json")];
         }
 
         $exit = 0;
 
         for ($i = 0; isset($packages[$i]); ++$i) {
-            [$dev, $package, $response] = $packages[$i];
+            [$dev, $package, $onlyVersion, $response] = $packages[$i];
             unset($packages[$i]);
 
             if (200 !== $response->getStatusCode()) {
@@ -46,6 +46,10 @@ class LintPackagesCommand extends Command
 
             foreach (glob("$package/*") as $version) {
                 $version = substr($version, 1 + \strlen($package));
+
+                if (null !== $onlyVersion && $version !== $onlyVersion) {
+                    continue;
+                }
 
                 if (!preg_match('/^\d+\.\d+$/D', $version)) {
                     $output->writeln(sprintf('::error::Version "%s" is not valid, format is "x.y" where x and y are numbers for "%s"', $version, $package));
@@ -76,7 +80,7 @@ class LintPackagesCommand extends Command
                         if (!$packages) {
                             $i = -1;
                         }
-                        $packages[] = [true, $package, $client->request('GET', "https://repo.packagist.org/p2/{$package}~dev.json")];
+                        $packages[] = [true, $package, $version, $client->request('GET', "https://repo.packagist.org/p2/{$package}~dev.json")];
                     }
 
                     continue;


### PR DESCRIPTION
It looks like that when a package version is not found on Packagist (here StimulusBundle 2.8), then the process fails for all other version of the package.

**Before:**
```
Error: Version "2.13" of "symfony/stimulus-bundle" does not exist on Packagist
Error: Version "2.20" of "symfony/stimulus-bundle" does not exist on Packagist
Error: Version "2.24" of "symfony/stimulus-bundle" does not exist on Packagist
Error: Version "2.25" of "symfony/stimulus-bundle" does not exist on Packagist
Error: Version "2.8" of "symfony/stimulus-bundle" does not exist on Packagist
Error: Version "2.9" of "symfony/stimulus-bundle" does not exist on Packagist
```

**After:**
```
Error: Version "2.8" of "symfony/stimulus-bundle" does not exist on Packagist
```
